### PR TITLE
Fix warnings, add lexical-binding, enhance docstrings, and add *.elc …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.cask/
 /test.md
 /result
+*.elc

--- a/test/markdown-toc-test.el
+++ b/test/markdown-toc-test.el
@@ -412,7 +412,7 @@ For this, you need to install a snippet of code in your emacs configuration file
 #### Git
 #### Tar
 "
-                  (markdown-toc-generate-toc 'replace-old-toc)))))
+                  (markdown-toc-generate-toc)))))
 
 (ert-deftest test-markdown-toc-generate-or-refresh-toc--with-existing-toc ()
   ;; Update an existing TOC


### PR DESCRIPTION
…to .gitignore

- Fix warnings
- Add lexical-binding
- Enhance docstrings
- Add *.elc to .gitignore
- Remove (point-at-eol) and (point-at-bol) as they are deprecated
- Remove key mappings as they are reserved. See key binding conventions in the Emacs documentation.